### PR TITLE
Check root element existence before mounting

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,13 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 
 // Punto de entrada de la aplicación
-const rootElement = document.getElementById('root') as HTMLElement;
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  console.error("No se encontró el nodo 'root' en el DOM.");
+  throw new Error("Root element not found");
+}
+
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- prevent ReactDOM.createRoot call when #root is missing and throw an explicit error

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b98e9e5630832db50a3c819ba6b4ac